### PR TITLE
Add basic playback controls for play, pause, skip, restart

### DIFF
--- a/src/common/hooks/usePlaybackState.ts
+++ b/src/common/hooks/usePlaybackState.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import { fetchQuery, graphql, requestSubscription, useMutation } from "react-relay";
+
+import environment from "../graphqlEnvironment";
+import { usePlaybackStateMutation } from "./__generated__/usePlaybackStateMutation.graphql";
+import { usePlaybackStateQuery } from "./__generated__/usePlaybackStateQuery.graphql";
+import { usePlaybackStateSubscription } from "./__generated__/usePlaybackStateSubscription.graphql";
+
+const playbackStateQuery = graphql`
+  query usePlaybackStateQuery {
+    playbackState
+  }
+`;
+
+const playbackStateMutation = graphql`
+  mutation usePlaybackStateMutation($playbackState: PlaybackState!) {
+    setPlaybackState(playbackState: $playbackState)
+  }
+`;
+
+const playbackStateSubscription = graphql`
+  subscription usePlaybackStateSubscription {
+    playbackStateChanged
+  }
+`;
+
+type StateType = usePlaybackStateQuery["response"]["playbackState"];
+
+export default function usePlaybackState() {
+  const [playbackState, setLocalPlaybackState] = useState<StateType>("WAITING");
+  const [commit] = useMutation<usePlaybackStateMutation>(playbackStateMutation);
+
+  useEffect(() => {
+    const initialQuery = fetchQuery<usePlaybackStateQuery>(
+      environment,
+      playbackStateQuery,
+      {}
+    )
+      // @ts-ignore: @types/react-relay has wrong return type for fetchQuery
+      .subscribe({
+        next: (response: usePlaybackStateQuery["response"]) => setLocalPlaybackState(response.playbackState),
+      });
+
+    const subscription = requestSubscription<usePlaybackStateSubscription>(
+      environment,
+      {
+        subscription: playbackStateSubscription,
+        variables: {},
+        onNext: (response) => {
+          if (response) setLocalPlaybackState(response.playbackStateChanged);
+        },
+      }
+    );
+
+    return () => {
+      initialQuery.unsubscribe();
+      subscription.dispose();
+    };
+  }, []);
+
+  const setPlaybackState = (nextPlaybackState: StateType) => {
+    setLocalPlaybackState(nextPlaybackState);
+    commit({ variables: { playbackState: nextPlaybackState } });
+  };
+
+  return { playbackState, setPlaybackState };
+}

--- a/src/common/schema.graphql
+++ b/src/common/schema.graphql
@@ -6,6 +6,7 @@ type Query {
   queue: [QueueItem!]!
   history(first: Int, after: String): HistoryConnection!
   youtubeVideoInfo(videoId: String): YoutubeVideoInfoResult!
+  playbackState: PlaybackState!
 }
 
 type Mutation {
@@ -15,9 +16,11 @@ type Mutation {
   queueYoutubeSong(input: QueueYoutubeSongInput): Int!
   popSong: QueueItem
   removeSong(songId: String!, timestamp: String!): Boolean!
+  setPlaybackState(playbackState: PlaybackState!): Boolean!
 }
 
 type Subscription {
+  playbackStateChanged: PlaybackState!
   queueChanged: [QueueItem!]!
   queueAdded: QueueItem!
 }
@@ -170,3 +173,11 @@ type YoutubeVideoInfoError {
 }
 
 union YoutubeVideoInfoResult = YoutubeVideoInfo | YoutubeVideoInfoError
+
+enum PlaybackState {
+  PAUSED
+  PLAYING
+  RESTARTING
+  SKIPPING
+  WAITING
+}

--- a/src/remocon/Controls.tsx
+++ b/src/remocon/Controls.tsx
@@ -11,6 +11,7 @@ import { Link } from "react-router-dom";
 
 import { withLoader } from "../common/components/Loader";
 import useQueue from "../common/hooks/useQueue";
+import PlaybackControls from "./components/PlaybackControls";
 import { ControlsRemoveSongMutation } from "./__generated__/ControlsRemoveSongMutation.graphql";
 
 interface QueueLinkProps {
@@ -82,9 +83,12 @@ const Controls = () => {
   };
 
   return (
-    <div className="collection">
-      {queue.map(([item, eta], i) => {
-        return (
+    <>
+      <div className="section">
+        <PlaybackControls />
+      </div>
+      <div className="collection">
+        {queue.map(([item, eta], i) => (
           <div
             key={`${item.id}_${i}`}
             className="collection-item"
@@ -113,9 +117,9 @@ const Controls = () => {
               ❌
             </div>
           </div>
-        );
-      })}
-    </div>
+        ))}
+      </div>
+    </>
   );
 };
 

--- a/src/remocon/components/PlaybackControls.tsx
+++ b/src/remocon/components/PlaybackControls.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import usePlaybackState from "../../common/hooks/usePlaybackState";
+
+const PlaybackControls = () => {
+  const { playbackState, setPlaybackState } = usePlaybackState();
+  const disabled = !["PLAYING", "PAUSED"].includes(playbackState);
+
+  return (
+    <div className="center">
+      <a
+        className={`btn-floating btn-medium red ${disabled ? "disabled" : ""}`}
+        onClick={() => setPlaybackState("RESTARTING")}
+      >
+        <i className="medium material-icons">replay</i>
+      </a>
+      <a
+        className={`btn-floating btn-large red ${disabled ? "disabled" : ""}`}
+        onClick={() =>
+          setPlaybackState(playbackState === "PAUSED" ? "PLAYING" : "PAUSED")
+        }
+      >
+        <i className="large material-icons">
+          {playbackState === "PLAYING" ? "pause" : "play_arrow"}
+        </i>
+      </a>
+      <a
+        className={`btn-floating btn-medium red ${disabled ? "disabled" : ""}`}
+        onClick={() => setPlaybackState("SKIPPING")}
+      >
+        <i className="medium material-icons">skip_next</i>
+      </a>
+    </div>
+  );
+};
+
+export default PlaybackControls;


### PR DESCRIPTION
This branch adds playback controls to the remocon to pause/play, skip, and restart songs.
Tested state transitions manually.

Implements #52 

Actions are disabled when no song is currently loaded (also disabled while the player is skipping or restarting)
![localhost_8080_(iPhone 6_7_8)](https://user-images.githubusercontent.com/9064684/126739980-5635d9e7-8bad-4b05-824a-cf7711c18a06.png)

Pause button when song is playing
![localhost_8080_(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/9064684/126739990-50aa4525-d764-482b-9f17-df12366c7450.png)

Play button when song is paused
![localhost_8080_(iPhone 6_7_8) (2)](https://user-images.githubusercontent.com/9064684/126739987-5a29d0aa-f53f-4296-aa21-20757f9b8012.png)
