### PR TITLE
Use yt-dlp instead of ytdl-core. Add support for downloading Youtube captions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ yarn-error.log*
 
 # react-relay
 __generated__
+
+# Extra resources that are downloaded on build
+/extraResources/ffmpeg/**/*
+/extraResources/ytdlp/*

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "native-debug": "cargo build --manifest-path native/Cargo.toml",
     "native-release": "cargo build --manifest-path native/Cargo.toml --release",
     "compile": "relay-compiler --schema src/common/schema.graphql --src src --language typescript && webpack",
-    "build": "yarn native-release && yarn compile && electron-builder -c.extraMetadata.main=./build/main/main.js --publish never",
-    "start": "yarn native-debug && yarn compile && concurrently \"webpack serve\" \"wait-on http://localhost:3000 && cross-env NODE_ENV=development electron .\"",
+    "build": "yarn get-external-resources && yarn native-release && yarn compile && electron-builder -c.extraMetadata.main=./build/main/main.js --publish never",
+    "start": "cross-env-shell NODE_ENV=development \"yarn _start\"",
+    "_start": "yarn get-external-resources && yarn native-debug && yarn compile && concurrently \"webpack serve\" \"wait-on http://localhost:3000 && electron .\"",
+    "get-external-resources": "node --harmony-top-level-await scripts/getExternalResources.mjs",
     "postinstall": "husky install"
   },
   "dependencies": {
@@ -48,10 +50,10 @@
     "ts-invariant": "^0.9.1",
     "user-agents": "^1.0.658",
     "wanakana": "^4.0.2",
-    "youtube-player": "^5.5.2",
-    "ytdl-core": "^4.8.3"
+    "youtube-player": "^5.5.2"
   },
   "devDependencies": {
+    "7zip-bin": "^5.1.1",
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-react": "^7.12.7",
     "@types/color-convert": "^2.0.0",
@@ -103,6 +105,9 @@
   },
   "build": {
     "appId": "com.karafriends.kara",
+    "extraResources": [
+      "./extraResources/**"
+    ],
     "files": [
       "build/**/**",
       "icon.png"

--- a/scripts/getExternalResources.mjs
+++ b/scripts/getExternalResources.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/node
+import fetch from "node-fetch";
+import sevenBin from "7zip-bin";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import process from "process";
+import { exec } from "child_process";
+
+let tmpDir;
+const pathTo7zip = sevenBin.path7za;
+const extraResourcesDir = `${process.cwd()}/extraResources`;
+
+async function downloadFile(url, path) {
+  const res = await fetch(url);
+  const fileStream = fs.createWriteStream(path);
+  await new Promise((resolve, reject) => {
+    res.body.pipe(fileStream);
+    res.body.on("error", reject);
+    fileStream.on("finish", resolve);
+  });
+}
+
+async function getExternalResources() {
+  const externalResourceChecks = [
+    fs.existsSync(`${extraResourcesDir}/ytdlp/yt-dlp`),
+    fs.existsSync(`${extraResourcesDir}/ytdlp/yt-dlp.exe`),
+    fs.existsSync(`${extraResourcesDir}/ytdlp/yt-dlp_macos`),
+    fs.existsSync(`${extraResourcesDir}/ffmpeg/win/ffmpeg.exe`),
+    fs.existsSync(`${extraResourcesDir}/ffmpeg/macos/ffmpeg`),
+    fs.existsSync(`${extraResourcesDir}/ffmpeg/linux/ffmpeg`),
+  ];
+  if (externalResourceChecks.every((check) => check === true)) {
+    return;
+  }
+  tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "karafriends_getExternalResources")
+  );
+  await Promise.all([
+    fs.mkdir(`${tmpDir}/ffmpeg/win`, { recursive: true }, () => null),
+    fs.mkdir(`${tmpDir}/ffmpeg/macos`, { recursive: true }, () => null),
+    fs.mkdir(`${tmpDir}/ffmpeg/linux`, { recursive: true }, () => null),
+    fs.mkdir(`${extraResourcesDir}/ytdlp`, { recursive: true }, () => null),
+    fs.mkdir(
+      `${extraResourcesDir}/ffmpeg/win`,
+      { recursive: true },
+      () => null
+    ),
+    fs.mkdir(
+      `${extraResourcesDir}/ffmpeg/macos`,
+      { recursive: true },
+      () => null
+    ),
+    fs.mkdir(
+      `${extraResourcesDir}/ffmpeg/linux`,
+      { recursive: true },
+      () => null
+    ),
+  ]);
+
+  await Promise.all([
+    downloadFile(
+      "https://github.com/yt-dlp/yt-dlp/releases/download/2022.04.08/yt-dlp",
+      `${extraResourcesDir}/ytdlp/yt-dlp`
+    ),
+    downloadFile(
+      "https://github.com/yt-dlp/yt-dlp/releases/download/2022.04.08/yt-dlp.exe",
+      `${extraResourcesDir}/ytdlp/yt-dlp.exe`
+    ),
+    downloadFile(
+      "https://github.com/yt-dlp/yt-dlp/releases/download/2022.04.08/yt-dlp_macos",
+      `${extraResourcesDir}/ytdlp/yt-dlp_macos`
+    ),
+    downloadFile(
+      "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z",
+      `${tmpDir}/ffmpeg/win/ffmpeg.7z`
+    ),
+    downloadFile(
+      "https://evermeet.cx/ffmpeg/ffmpeg-5.0.1.zip",
+      `${tmpDir}/ffmpeg/macos/ffmpeg.zip`
+    ),
+    downloadFile(
+      "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz",
+      `${tmpDir}/ffmpeg/linux/ffmpeg.tar.xz`
+    ),
+  ]);
+
+  const getWinFfmpeg = async () => {
+    exec(
+      `${pathTo7zip} e ${tmpDir}/ffmpeg/win/ffmpeg.7z -y -o${tmpDir}/ffmpeg/win/contents`,
+      (error, stdout, stderr) => {
+        fs.rename(
+          `${tmpDir}/ffmpeg/win/contents/ffmpeg.exe`,
+          `${extraResourcesDir}/ffmpeg/win/ffmpeg.exe`,
+          (err) => {
+            if (err) {
+              console.error(error);
+            }
+          }
+        );
+      }
+    );
+  };
+  const getMacosFfmpeg = async () => {
+    exec(
+      `${pathTo7zip} e ${tmpDir}/ffmpeg/macos/ffmpeg.zip -y -o${tmpDir}/ffmpeg/macos/contents`,
+      (error, stdout, stderr) => {
+        fs.rename(
+          `${tmpDir}/ffmpeg/macos/contents/ffmpeg`,
+          `${extraResourcesDir}/ffmpeg/macos/ffmpeg`,
+          (err) => {
+            if (err) {
+              console.error(error);
+            }
+          }
+        );
+      }
+    );
+  };
+  const getLinuxFfmpeg = async () => {
+    exec(
+      `${pathTo7zip} e ${tmpDir}/ffmpeg/linux/ffmpeg.tar.xz -y -o${tmpDir}/ffmpeg/linux/xz`,
+      (error, stdout, stderr) => {
+        exec(
+          `${pathTo7zip} e ${tmpDir}/ffmpeg/linux/xz/ffmpeg.tar -y -o${tmpDir}/ffmpeg/linux/contents`,
+          (error, stdout, stderr) => {
+            fs.rename(
+              `${tmpDir}/ffmpeg/linux/contents/ffmpeg`,
+              `${extraResourcesDir}/ffmpeg/linux/ffmpeg`,
+              (err) => {
+                if (err) {
+                  console.error(error);
+                }
+              }
+            );
+          }
+        );
+      }
+    );
+  };
+  await Promise.all([getLinuxFfmpeg(), getMacosFfmpeg(), getWinFfmpeg()]);
+}
+
+await getExternalResources();

--- a/src/common/schema.graphql
+++ b/src/common/schema.graphql
@@ -119,6 +119,7 @@ input QueueYoutubeSongInput {
   playtime: Int
   nickname: String!
   adhocSongLyrics: String
+  captionCode: String
 }
 
 type SongConnection {
@@ -176,12 +177,19 @@ type YoutubeQueueItem implements QueueItemInterface {
   timestamp: String!
   nickname: String!
   hasAdhocLyrics: Boolean!
+  hasCaptions: Boolean!
 }
 
 union QueueItem = DamQueueItem | YoutubeQueueItem
 
+type CaptionLanguage {
+  code: String!
+  name: String!
+}
+
 type YoutubeVideoInfo {
   author: String!
+  captionLanguages: [CaptionLanguage!]!
   channelId: String!
   keywords: [String!]
   lengthSeconds: Int!

--- a/src/common/videoDownloader.ts
+++ b/src/common/videoDownloader.ts
@@ -59,7 +59,7 @@ export function downloadYoutubeVideo(
     ? `--write-subs --sub-langs ${captionCode}`
     : "";
   exec(
-    `${resourcePaths.ytdlp} ${captionArgs} -S res,ext:mp4:m4a --recode mp4 --ffmpeg-location "${resourcePaths.ffmpeg}" -o "${writeBasePath}.mp4" -- "${videoId}"`,
+    `${resourcePaths.ytdlp} ${captionArgs} -S res,ext:mp4:m4a --recode mp4 -N 4 --ffmpeg-location "${resourcePaths.ffmpeg}" -o "${writeBasePath}.mp4" -- "${videoId}"`,
     (error, stdout, stderr) => {
       if (error) {
         console.error(

--- a/src/common/videoDownloader.ts
+++ b/src/common/videoDownloader.ts
@@ -1,27 +1,87 @@
+import { exec } from "child_process";
 import { app } from "electron"; // tslint:disable-line:no-implicit-dependencies
 import fs from "fs";
-import ytdl from "ytdl-core";
+import process from "process";
 
 export const TEMP_FOLDER: string = `${app.getPath("temp")}/karafriends_tmp`;
+const youtubeIdRe: RegExp = new RegExp(/[0-9A-Za-z_-]{10}[048AEIMQUYcgkosw]/);
+const extraResourcesPath: string =
+  process.env.NODE_ENV === "development"
+    ? `${app.getAppPath()}/extraResources/`
+    : `${process.resourcesPath}/extraResources/`;
+
+interface YtdlResourcePaths {
+  // Path to the directory containing the ffmpeg executable
+  ffmpeg: string;
+  // Path to the ytdlp executable
+  ytdlp: string;
+}
+
+const linuxResourcePaths: YtdlResourcePaths = {
+  ffmpeg: `${extraResourcesPath}/ffmpeg/linux/`,
+  ytdlp: `${extraResourcesPath}/ytdlp/yt-dlp`,
+};
+
+const macosResourcePaths: YtdlResourcePaths = {
+  ffmpeg: `${extraResourcesPath}/ffmpeg/macos/`,
+  ytdlp: `${extraResourcesPath}/ytdlp/yt-dlp_macos`,
+};
+
+const winResourcePaths: YtdlResourcePaths = {
+  ffmpeg: `${extraResourcesPath}/ffmpeg/win/`,
+  ytdlp: `${extraResourcesPath}/ytdlp/yt-dlp.exe`,
+};
+
+const resourcePaths: YtdlResourcePaths =
+  process.platform === "win32"
+    ? winResourcePaths
+    : process.platform === "darwin"
+    ? macosResourcePaths
+    : linuxResourcePaths;
 
 export function downloadYoutubeVideo(
   videoId: string,
+  captionCode: string | null,
   onComplete: () => any
 ): void {
+  // Make sure videoId is a valid ID. Don't want to pass just anything into a raw shell command
+  if (!youtubeIdRe.test(videoId)) {
+    console.error(
+      `Error downloading Youtube Video. ${videoId} is not a valid YouTube video ID`
+    );
+    return;
+  }
   if (!fs.existsSync(TEMP_FOLDER)) {
     fs.mkdirSync(TEMP_FOLDER);
   }
-  const writePath = `${TEMP_FOLDER}/${videoId}.mp4`;
-  if (fs.existsSync(writePath)) {
-    onComplete();
-    return;
-  }
-
-  const video = ytdl(videoId, {
-    filter: (format) =>
-      format.container === "mp4" && format.hasVideo && format.hasAudio,
-    quality: "highestvideo",
-  });
-  video.on("end", onComplete);
-  video.pipe(fs.createWriteStream(writePath));
+  const writeBasePath = `${TEMP_FOLDER}/${videoId}`;
+  const captionArgs = captionCode
+    ? `--write-subs --sub-langs ${captionCode}`
+    : "";
+  exec(
+    `${resourcePaths.ytdlp} ${captionArgs} -S res,ext:mp4:m4a --recode mp4 --ffmpeg-location "${resourcePaths.ffmpeg}" -o "${writeBasePath}.mp4" -- "${videoId}"`,
+    (error, stdout, stderr) => {
+      if (error) {
+        console.error(
+          `Error downloading Youtube Video with ID ${videoId}: ${error}`
+        );
+        return;
+      }
+      if (captionCode) {
+        try {
+          fs.renameSync(
+            `${writeBasePath}.${captionCode}.vtt`,
+            `${writeBasePath}.vtt`
+          );
+        } catch (fsError) {
+          console.error(
+            `Error trying to rename caption file ${writeBasePath}.${captionCode}.vtt to ${writeBasePath}.vtt: ${fsError}`
+          );
+        }
+      }
+      console.log(stdout);
+      console.error(stderr);
+      onComplete();
+    }
+  );
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,21 +58,24 @@ function createWindow() {
     },
   });
 
-  // Ignore CORS when fetching ipcasting HLS
+  // Ignore CORS when fetching ipcasting HLS and when sending requests to remocon
   const session = rendererWindow.webContents.session;
-  const ipcastingFilter = {
-    urls: ["https://*.ipcasting.jp/*"],
+  const ignoreCORSFilter = {
+    urls: [
+      "https://*.ipcasting.jp/*",
+      "http://localhost:8080/*",
+    ],
   };
 
   session.webRequest.onBeforeSendHeaders(
-    ipcastingFilter,
+    ignoreCORSFilter,
     (details, callback) => {
       delete details.requestHeaders.Origin;
       callback({ requestHeaders: details.requestHeaders });
     }
   );
 
-  session.webRequest.onHeadersReceived(ipcastingFilter, (details, callback) => {
+  session.webRequest.onHeadersReceived(ignoreCORSFilter, (details, callback) => {
     details.responseHeaders!["Access-Control-Allow-Origin"] = ["*"];
     callback({ responseHeaders: details.responseHeaders });
   });

--- a/src/main/youtubeApi.ts
+++ b/src/main/youtubeApi.ts
@@ -28,6 +28,17 @@ interface GetVideoInfoResponse {
     status: string;
     reason: string;
   };
+  captions?: {
+    playerCaptionsTracklistRenderer: {
+      captionTracks: [{
+        name: {
+          simpleText: string;
+        };
+        vssId: string;
+        languageCode: string;
+      }];
+    };
+  };
   videoDetails: {
     videoId: string;
     title: string;

--- a/src/remocon/YoutubeInfo.css
+++ b/src/remocon/YoutubeInfo.css
@@ -37,3 +37,15 @@
 .lyrics-input-container {
   margin-right: 1em;
 }
+
+.radio-item {
+  margin-top: 0em;
+}
+
+#add-lyrics {
+  margin-left: 0.5em;
+}
+
+.add-lyrics-section {
+  margin-top: 0em
+}

--- a/src/remocon/YoutubeInfo.tsx
+++ b/src/remocon/YoutubeInfo.tsx
@@ -10,6 +10,8 @@ import {
 } from "./__generated__/YoutubeInfoVideoInfoQuery.graphql";
 
 import "./YoutubeInfo.css";
+import "materialize-css/dist/css/materialize.css"; // tslint:disable-line:no-submodule-imports
+
 
 const youtubeInfoVideoInfoQuery = graphql`
   query YoutubeInfoVideoInfoQuery($videoId: String!) {
@@ -17,6 +19,10 @@ const youtubeInfoVideoInfoQuery = graphql`
       ... on YoutubeVideoInfo {
         __typename
         author
+        captionLanguages {
+          name
+          code
+        }
         channelId
         keywords
         lengthSeconds
@@ -44,6 +50,7 @@ function YoutubeInfo(props: YoutubeInfoProps) {
   > | null> = useRef(null);
   const { videoId } = props;
   const [adhocSongLyrics, setAdhocSongLyrics] = useState<string | null>(null);
+  const [selectedCaption, setSelectedCaption] = useState<string | undefined>(undefined);
   const videoData = useLazyLoadQuery<YoutubeInfoVideoInfoQuery>(
     youtubeInfoVideoInfoQuery,
     { videoId }
@@ -110,11 +117,36 @@ function YoutubeInfo(props: YoutubeInfoProps) {
                 playtime: videoData.youtubeVideoInfo.lengthSeconds,
                 nickname: localStorage.getItem("nickname") || "unknown",
                 adhocSongLyrics,
+                captionCode: selectedCaption || null,
               },
             }}
           />
         </div>
+        <h5 id="add-lyrics">Add Lyrics:</h5>
+        <div className="flex-container flex-vertical flex-item add-lyrics-section">
+          <h6 className="add-lyrics-section">From Captions</h6>
+          <label className="flex-item radio-item">
+            <input
+              checked={selectedCaption === undefined}
+              name="captions" type="radio" value={undefined}
+              onChange={(event) => {setSelectedCaption(undefined)}}
+            />
+          <span>None</span>
+          </label>
+          {videoData.youtubeVideoInfo.captionLanguages.map((captionLanguage) => {
+            return (<label className="flex-item radio-item">
+              <input
+                checked={selectedCaption === captionLanguage.code}
+                name="captions" type="radio"
+                value={captionLanguage.code}
+                onChange={(event) => {setSelectedCaption(captionLanguage.code)}}
+              />
+              <span>{captionLanguage.name}</span>
+            </label>)
+          })}
+        </div>
         <div className="flex-item lyrics-input-container">
+          <h6 className="add-lyrics-section">Manual Lyrics</h6>
           <textarea
             onChange={onAdhocSongLyricsChanged}
             placeholder={

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const { merge } = require("webpack-merge");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 const COMMON_CONFIG = {
-  mode: "development",
   resolve: {
     alias: {
       graphql$: path.resolve(__dirname, "./node_modules/graphql/index.js"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"7zip-bin@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-5.1.1.tgz#9274ec7460652f9c632c59addf24efb1684ef876"
+  integrity sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==
+
 "7zip-bin@~5.0.3":
   version "5.0.3"
   resolved "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.0.3.tgz"
@@ -5490,14 +5495,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-m3u8stream@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.3.tgz"
-  integrity sha512-0nAcdrF8YJKUkb6PzWdvGftTPyCVWgoiot1AkNVbPKTeIGsWs6DrOjifrJ0Zi8WQfQmD2SuVCjkYIOip12igng==
-  dependencies:
-    miniget "^4.0.0"
-    sax "^1.2.4"
-
 make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
@@ -5655,11 +5652,6 @@ mini-css-extract-plugin@^1.3.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
     webpack-sources "^1.1.0"
-
-miniget@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/miniget/-/miniget-4.2.1.tgz"
-  integrity sha512-O/DduzDR6f+oDtVype9S/Qu5hhnx73EDYGyZKwU/qN82lehFZdfhoa4DT51SpsO+8epYrB3gcRmws56ROfTIoQ==
 
 minimalistic-assert@^1.0.0:
   version "1.0.1"
@@ -7011,7 +7003,7 @@ sanitize-filename@^1.6.2, sanitize-filename@^1.6.3:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-sax@^1.1.3, sax@^1.2.4:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -8589,15 +8581,6 @@ youtube-player@^5.5.2:
     debug "^2.6.6"
     load-script "^1.0.0"
     sister "^3.0.0"
-
-ytdl-core@^4.8.3:
-  version "4.8.3"
-  resolved "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.8.3.tgz"
-  integrity sha512-cWCBeX4FCgjcKmuVK384MT582RIAakpUSeMF/NPVmhO8cWiG+LeQLnBordvLolb0iXYzfUvalgmycYAE5Sy6Xw==
-  dependencies:
-    m3u8stream "^0.8.3"
-    miniget "^4.0.0"
-    sax "^1.1.3"
 
 zen-observable-ts@^0.8.21:
   version "0.8.21"


### PR DESCRIPTION
Using yt-dlp is downloading stuff way faster than ytdl-core. No more queuing and wondering where your song went.
The yt-dlp (and ffmpeg which yt-dlp sometimes needs) executables get downloaded if missing and jammed as an extraResource upon build/start
Also added Youtube caption support which works, but gets a bit spotty if the source captions are too fancy since conversion from youtube's SRV3 subs to other subtitle formats like VTT are very far from 1:1. Spotty being that is has no color, it sometimes gets duped, and is sometimes misaligned.
