### PR TITLE
Use mv instead of fs.rename when getting external resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "keytar": "^7.7.0",
     "materialize-css": "^1.0.0-rc.2",
     "multicast-dns": "^7.2.2",
+    "mv": "^2.1.1",
     "niconico": "^1.2.0",
     "node-fetch": "^2.6.1",
     "polyline-normals": "^2.0.2",

--- a/scripts/getExternalResources.mjs
+++ b/scripts/getExternalResources.mjs
@@ -69,6 +69,7 @@ const winTasks = {
           (err) => {
             if (err) {
               console.error(error);
+              throw err;
             }
             hasFinishedExtracting[0] = true;
           }
@@ -115,6 +116,7 @@ const macosTasks = {
           (err) => {
             if (err) {
               console.error(error);
+              throw err;
             }
             hasFinishedExtracting[0] = true;
           }
@@ -167,6 +169,7 @@ const linuxTasks = {
               (err) => {
                 if (err) {
                   console.error(error);
+                  throw err;
                 }
                 hasFinishedExtracting[0] = true;
               }

--- a/scripts/getExternalResources.mjs
+++ b/scripts/getExternalResources.mjs
@@ -2,6 +2,7 @@
 import fetch from "node-fetch";
 import sevenBin from "7zip-bin";
 import fs from "fs";
+import mv from "mv";
 import os from "os";
 import path from "path";
 import process from "process";
@@ -63,7 +64,7 @@ const winTasks = {
     exec(
       `${pathTo7zip} e ${tmpDir}/ffmpeg/win/ffmpeg.7z -y -o${tmpDir}/ffmpeg/win/contents`,
       (error, stdout, stderr) => {
-        fs.rename(
+        mv(
           `${tmpDir}/ffmpeg/win/contents/ffmpeg.exe`,
           `${extraResourcesDir}/ffmpeg/win/ffmpeg.exe`,
           (err) => {
@@ -110,7 +111,7 @@ const macosTasks = {
     exec(
       `${pathTo7zip} e ${tmpDir}/ffmpeg/macos/ffmpeg.zip -y -o${tmpDir}/ffmpeg/macos/contents`,
       (error, stdout, stderr) => {
-        fs.rename(
+        mv(
           `${tmpDir}/ffmpeg/macos/contents/ffmpeg`,
           `${extraResourcesDir}/ffmpeg/macos/ffmpeg`,
           (err) => {
@@ -163,7 +164,7 @@ const linuxTasks = {
         exec(
           `${pathTo7zip} e ${tmpDir}/ffmpeg/linux/xz/ffmpeg.tar -y -o${tmpDir}/ffmpeg/linux/contents`,
           (error, stdout, stderr) => {
-            fs.rename(
+            mv(
               `${tmpDir}/ffmpeg/linux/contents/ffmpeg`,
               `${extraResourcesDir}/ffmpeg/linux/ffmpeg`,
               (err) => {
@@ -208,6 +209,10 @@ async function getExternalResources(tasks) {
       console.error(
         `Extracting ffmpeg did not complete after ${maxMsToWaitForExtraction} ms and was aborted!`
       );
+      process.exit(1);
+    }
+    if (!tasks.doChecks().every((check) => check === true)) {
+      console.error("An external resource wasn't successfuly downloaded!");
       process.exit(1);
     }
     tasks.setPermissions();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5172,6 +5172,17 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
@@ -7093,6 +7104,13 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
+"minimatch@2 || 3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
@@ -7100,7 +7118,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1:
+minimist@^1.1.1, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -7129,6 +7147,13 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@~0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 ms@2.0.0:
   version "2.0.0"
@@ -7166,6 +7191,15 @@ multicast-dns@^7.2.2:
     dns-packet "^4.0.0"
     thunky "^1.0.2"
 
+mv@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
 nan@^2.12.1:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
@@ -7202,6 +7236,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -8549,6 +8588,13 @@ rimraf@^3.0.0:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
+  dependencies:
+    glob "^6.0.1"
 
 roarr@^2.15.3:
   version "2.15.4"


### PR DESCRIPTION
The github build's temp directory and build directory are on different partitions
This makes doing an `fs.rename` between the two to blow up. Use `mv` instead which does an `fs.rename` but falls back to a copy and delete