### PR TITLE
Fixes gql in prod, at least for me

### DIFF
--- a/src/common/graphqlEnvironment.ts
+++ b/src/common/graphqlEnvironment.ts
@@ -36,7 +36,7 @@ const subscriptionClient = new SubscriptionClient(
   window.location.protocol === "file:"
     ? "ws://localhost:8080/subscriptions"
     : `${window.location.protocol === "https:" ? "wss" : "ws"}://${
-        window.location.host
+        window.location.hostname
       }:${window.location.port}/subscriptions`,
   {
     reconnect: true,


### PR DESCRIPTION
Was getting `Uncaught DOMException: Failed to construct 'WebSocket': The URL 'ws://10.0.0.62:8080:8080/subscriptions' is invalid.` in prod, and this fixes it.