### PR TITLE
Save and reload input devices automatically

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -93,6 +93,18 @@ function App() {
     )
   );
 
+  const onChangeMic = (index: number, newMic: InputDevice) => {
+    const updatedMics = [...mics];
+    const oldMic = updatedMics.splice(index, 1, newMic)[0];
+    if (oldMic) oldMic.stop();
+    setMics(updatedMics);
+  };
+
+  const clearMics = () => {
+    mics.forEach((mic) => mic.stop());
+    setMics([]);
+  };
+
   switch (appState) {
     case AppState.Loading:
     default:
@@ -117,20 +129,22 @@ function App() {
           <div className="appSidebar col s1 grey lighten-3">
             <QRCode hostname={hostname} />
             <nav className="center-align">Settings</nav>
-            <div>
+            <div className="section center-align">
               <HostnameSetting onChange={setHostname} />
-              {[...Array(mics.length + 1).keys()].map((i) => (
+              {mics.map((mic, i) => (
                 <MicrophoneSetting
-                  key={i}
-                  onChange={(name, channel) => {
-                    if (mics[i]) mics[i].stop();
-                    const updatedMics = [...mics];
-                    updatedMics[i] = new InputDevice(name, channel);
-                    setMics(updatedMics);
-                  }}
-                  value={mics[i] ? mics[i].name : ""}
+                  key={mic.deviceId}
+                  onChange={onChangeMic.bind(null, i)}
+                  mic={mic}
                 />
               ))}
+              <MicrophoneSetting
+                onChange={onChangeMic.bind(null, mics.length)}
+                mic={null}
+              />
+              <button className="btn" onClick={clearMics}>
+                Clear mics
+              </button>
             </div>
             <nav className="center-align">Queue</nav>
             <Queue />

--- a/src/renderer/MicrophoneSetting.tsx
+++ b/src/renderer/MicrophoneSetting.tsx
@@ -1,12 +1,27 @@
 import M from "materialize-css";
 import React, { useEffect } from "react";
 
+import { InputDevice } from "./audioSystem";
 import "./global";
 
-export default function MicrophoneSetting(props: {
-  onChange: (name: string, channelSelection: number) => void;
-  value: string;
-}) {
+const MicrophoneSettingOption = ({
+  name,
+  channel,
+}: {
+  name: string;
+  channel: number;
+}) => (
+  <option data-name={name} data-channel={channel} value={`${name}_${channel}`}>
+    {`${name} (${channel === -1 ? "All Channels" : `Channel ${channel}`})`}
+  </option>
+);
+
+interface Props {
+  mic: InputDevice | null;
+  onChange: (mic: InputDevice) => void;
+}
+
+export default function MicrophoneSetting({ mic, onChange }: Props) {
   useEffect(() => {
     M.AutoInit();
   }, []);
@@ -14,10 +29,14 @@ export default function MicrophoneSetting(props: {
   return (
     <div className="input-field">
       <select
-        value={props.value}
+        value={mic ? `${mic.name}_${mic.channelSelection}` : ""}
         onChange={(e) => {
           const dataset = e.target.options[e.target.selectedIndex].dataset;
-          props.onChange(dataset.name!, parseInt(dataset.channel!, 10));
+          const newMic = new InputDevice(
+            dataset.name!,
+            parseInt(dataset.channel!, 10)
+          );
+          onChange(newMic);
         }}
       >
         <option value="" disabled={true}>
@@ -26,17 +45,13 @@ export default function MicrophoneSetting(props: {
         {window.karafriends.nativeAudio
           .inputDevices()
           .map(([name, channelCount]) =>
-            [
-              <option data-name={name} data-channel={-1} key={`${name}_${-1}`}>
-                {`${name} (All Channels)`}
-              </option>,
-            ].concat(
-              [...Array(channelCount)].map((_, i) => (
-                <option data-name={name} data-channel={i} key={`${name}_${i}`}>
-                  {`${name} (Channel ${i})`}
-                </option>
-              ))
-            )
+            [...Array(channelCount + 1)].map((_, i) => (
+              <MicrophoneSettingOption
+                key={`${name}_${i - 1}`}
+                name={name}
+                channel={i - 1}
+              />
+            ))
           )}
       </select>
       <label>Microphone</label>

--- a/src/renderer/audioSystem.ts
+++ b/src/renderer/audioSystem.ts
@@ -5,6 +5,7 @@ const registry = new FinalizationRegistry(
 export class InputDevice {
   deviceId: number;
   name: string;
+  channelSelection: number;
 
   constructor(name: string, channelSelection: number) {
     this.deviceId = window.karafriends.nativeAudio.inputDevice_new(
@@ -12,6 +13,7 @@ export class InputDevice {
       channelSelection
     );
     this.name = name;
+    this.channelSelection = channelSelection;
     registry.register(this, this.deviceId);
   }
 


### PR DESCRIPTION
Saves selected mics to localStorage so they can be loaded automatically next time you open or reload the app.